### PR TITLE
Support scoop package also 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,46 +43,18 @@ You need first to add this bucket
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 ```
 
-Then you can install **one of** the binaries: 
+Then type the following command to install TinyTeX: 
 
-* Recommanded installation of `TinyTeX.zip`
 ```powershell
-scoop install TinyTeX
-```
-
-* Minimal installation (infra-only) of `TinyTeX-0.zip`
-```powershell
-scoop install TinyTeX-min
-```
-
-* Full installation (more packages) of `TinyTeX-1.zip`
-```powershell
-scoop install TinyTeX-min
+scoop install tinytex
 ```
 
 This will install TinyTeX and make the TeX Live package manager, `tlmgr` available on PATH.
 
-Only one of this installation can work at the same time, so you won't be able to install one on an other. This will fail gracefully:
+To uninstall TinyTeX, use the command:
 
 ```powershell
-❯ scoop install TinyTeX-min
-Installing 'TinyTeX-min' (2020.09) [64bit]
-Starting download ...
-Download: (OK):download completed.
-Checking hash of TinyTeX-0.zip ... ok.
-Extracting TinyTeX-0.zip ... done.
-Running pre-install script...
---> Another TinyTeX already found. Cancelling current installation...
-Uninstalling 'TinyTeX-min' (2020.09).
-'TinyTeX-min' was uninstalled.
-Exception: You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTeX-min.
+scoop uninstall tinytex
 ```
 
-To uninstall :
-```powershell
-scoop uninstall TinyTeX
-# or 
-scoop uninstall TinyTeX-min
-# or 
-scoop uninstall TinyTeX-full
-```
+For more information on this scoop package, please see https://github.com/cderv/r-bucket/.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ choco uninstall tinytex
 
 Scoop is another package manager for Windows. You need to install [_scoop_](https://scoop-docs.now.sh/docs/getting-started/Quick-Start.html) first to use it from powershell.
 
-Apps for _scoop_ are available through "buckets". For now, TinyTex binary packages are not available in the default **main** or **extras** buckets that comes with a new installation of _scoop_, but through the scoop bucket **r-bucket** at https://github.com/cderv/r-bucket/ with other R-related tools.
+Apps for _scoop_ are available through "buckets". For now, TinyTeX binary packages are not available in the default **main** or **extras** buckets that comes with a new installation of _scoop_, but through the scoop bucket **r-bucket** at https://github.com/cderv/r-bucket/ with other R-related tools.
 
 You need first to add this bucket
 ```powershell 
@@ -47,17 +47,17 @@ Then you can install **one of** the binaries:
 
 * Recommanded installation of `TinyTeX.zip`
 ```powershell
-scoop install TinyTex
+scoop install TinyTeX
 ```
 
 * Minimal installation (infra-only) of `TinyTeX-0.zip`
 ```powershell
-scoop install TinyTex-min
+scoop install TinyTeX-min
 ```
 
 * Full installation (more packages) of `TinyTeX-1.zip`
 ```powershell
-scoop install TinyTex-min
+scoop install TinyTeX-min
 ```
 
 This will install TinyTeX and make the TeX Live package manager, `tlmgr` available on PATH.
@@ -65,24 +65,24 @@ This will install TinyTeX and make the TeX Live package manager, `tlmgr` availab
 Only one of this installation can work at the same time, so you won't be able to install one on an other. This will fail gracefully:
 
 ```powershell
-❯ scoop install TinyTex-min
-Installing 'TinyTex-min' (2020.09) [64bit]
+❯ scoop install TinyTeX-min
+Installing 'TinyTeX-min' (2020.09) [64bit]
 Starting download ...
 Download: (OK):download completed.
 Checking hash of TinyTeX-0.zip ... ok.
 Extracting TinyTeX-0.zip ... done.
 Running pre-install script...
---> Another TinyTex already found. Cancelling current installation...
-Uninstalling 'TinyTex-min' (2020.09).
-'TinyTex-min' was uninstalled.
-Exception: You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-min.
+--> Another TinyTeX already found. Cancelling current installation...
+Uninstalling 'TinyTeX-min' (2020.09).
+'TinyTeX-min' was uninstalled.
+Exception: You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTeX-min.
 ```
 
 To uninstall :
 ```powershell
-scoop uninstall TinyTex
+scoop uninstall TinyTeX
 # or 
-scoop uninstall TinyTex-min
+scoop uninstall TinyTeX-min
 # or 
-scoop uninstall TinyTex-full
+scoop uninstall TinyTeX-full
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To uninstall TinyTeX, use the command:
 choco uninstall tinytex
 ```
 
-## Scoop packages
+## Scoop package
 
 Scoop is another package manager for Windows. You need to install [_scoop_](https://scoop-docs.now.sh/docs/getting-started/Quick-Start.html) first to use it from powershell.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,57 @@ To uninstall TinyTeX, use the command:
 choco uninstall tinytex
 ```
 
-## Scoop package
+## Scoop packages
 
-Coming...
+Scoop is another package manager for Windows. You need to install [_scoop_](https://scoop-docs.now.sh/docs/getting-started/Quick-Start.html) first to use it from powershell.
+
+Apps for _scoop_ are available through "buckets". For now, TinyTex binary packages are not available in the default **main** or **extras** buckets that comes with a new installation of _scoop_, but through the scoop bucket **r-bucket** at https://github.com/cderv/r-bucket/ with other R-related tools.
+
+You need first to add this bucket
+```powershell 
+scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
+```
+
+Then you can install **one of** the binaries: 
+
+* Recommanded installation of `TinyTeX.zip`
+```powershell
+scoop install TinyTex
+```
+
+* Minimal installation (infra-only) of `TinyTeX-0.zip`
+```powershell
+scoop install TinyTex-min
+```
+
+* Full installation (more packages) of `TinyTeX-1.zip`
+```powershell
+scoop install TinyTex-min
+```
+
+This will install TinyTeX and make the TeX Live package manager, `tlmgr` available on PATH.
+
+Only one of this installation can work at the same time, so you won't be able to install one on an other. This will fail gracefully:
+
+```powershell
+❯ scoop install TinyTex-min
+Installing 'TinyTex-min' (2020.09) [64bit]
+Starting download ...
+Download: (OK):download completed.
+Checking hash of TinyTeX-0.zip ... ok.
+Extracting TinyTeX-0.zip ... done.
+Running pre-install script...
+--> Another TinyTex already found. Cancelling current installation...
+Uninstalling 'TinyTex-min' (2020.09).
+'TinyTex-min' was uninstalled.
+Exception: You already have Tinytex installed. Run scoop uninstall Tinytex if you want to use TinyTex-min.
+```
+
+To uninstall :
+```powershell
+scoop uninstall TinyTex
+# or 
+scoop uninstall TinyTex-min
+# or 
+scoop uninstall TinyTex-full
+```


### PR DESCRIPTION
This PR is just an update to the README because everything is done in the scoop bucket I created already for rstudio-daily installation: https://github.com/cderv/r-bucket

You can see the README there and the PR https://github.com/cderv/r-bucket/pull/1

As it is pretty simple to create a manifest for support a package, I added the 3 binaries. `TinyTex-1.zip`, `TinyTex-0.zip` and `TinyTex.zip` where not explicit names so I used `TinyTex` (for Rmd support - recommanded one I guess), `TinyTex-full` and `TinyTex-min`. Notice I kept the upper T in the name. 

* **Should we use `tinytex` as for choco ?**
* **Should we offer only one package instead ?**

For the install step I did the same as in your choco script
* tlmgr path add (without admin right, so in user mode)
* creating a shim only for `tlmgr`

**Is this correct ?** 
I was note sure what was the purpose of 
https://github.com/yihui/tinytex-releases/blob/617697a37f6bbc3cb591fd271ac91f9460718646/choco/tools/chocolateyinstall.ps1#L18-L22
but I supposed it was choco-only related.

IMO This works as expected. 

And also the **r-bucket** is automatically updated thanks to a GHA workflow. So as soon as a release is done here, the manifest in the bucket will be updated. 

@yihui I let you look into it, and discuss here. I will make the change in the bucket accordingly. 

We could also decide to make `TinyTex-releases` as bucket - but there would only be TinyTex in it. 
We could also make a PR into https://github.com/ScoopInstaller/Main or https://github.com/lukesampson/scoop-extras which the 2 default bucket you got setup when installing scoop. 